### PR TITLE
Fix overlap of update check with menu icon and settings not opening on macOS 15 beta

### DIFF
--- a/Clapet/AppDelegate.swift
+++ b/Clapet/AppDelegate.swift
@@ -3,6 +3,8 @@ import SwiftUI
 
 class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, ObservableObject {
     
+    static var isVisible: Bool = true;
+    
     let updateService: UpdateService
     let notificationService: NotificationService
     let inactivityService: InactivityService
@@ -10,6 +12,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, Observable
     
     @AppStorage(StorageKeys.alreadySetup)
     private var alreadySetup: Bool = StorageDefaults.alreadySetup
+    
+    @AppStorage(StorageKeys.showDockIcon)
+    private var showDockIcon: Bool = StorageDefaults.showDockIcon
     
     override init() {
         self.updateService = UpdateService()
@@ -28,21 +33,30 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, Observable
         sleepService.initialize()
         
         if alreadySetup {
+            if !self.showDockIcon {
+                AppDelegate.hideApplication()
+            }
+            
             updateService.checkForUpdate()
         }
     }
     
+    static func isApplicationVisible() -> Bool {
+        return Self.isVisible;
+    }
+    
     static func showApplication(bringToFront: Bool = false) {
+        Self.isVisible = true;
         NSApp.setActivationPolicy(.regular)
         
         if bringToFront {
             NSApp.activate(ignoringOtherApps: true)
-            NSApp.windows.last?.orderFrontRegardless()
+            NSApp.windows.filter({ $0.isVisible }).last?.orderFrontRegardless()
         }
     }
     
     static func hideApplication() {
+        Self.isVisible = false;
         NSApp.setActivationPolicy(.prohibited);
     }
-    
 }

--- a/Clapet/ClapetApp.swift
+++ b/Clapet/ClapetApp.swift
@@ -55,11 +55,11 @@ struct ClapetApp: App {
         }
         
         Settings {
-            if alreadySetup {
+//            if alreadySetup {
                 SettingsView()
                     .environmentObject(delegate.inactivityService)
                     .environmentObject(delegate.sleepService)
-            }
+//            }
         }
     }
     

--- a/Clapet/ClapetApp.swift
+++ b/Clapet/ClapetApp.swift
@@ -55,11 +55,11 @@ struct ClapetApp: App {
         }
         
         Settings {
-//            if alreadySetup {
+            if alreadySetup {
                 SettingsView()
                     .environmentObject(delegate.inactivityService)
                     .environmentObject(delegate.sleepService)
-//            }
+            }
         }
     }
     

--- a/Clapet/Services/SleepService.swift
+++ b/Clapet/Services/SleepService.swift
@@ -31,6 +31,9 @@ class SleepService: ObservableObject {
     @AppStorage(StorageKeys.closedLidForceSleep)
     private var closedLidForceSleep: Bool = StorageDefaults.closedLidForceSleep
     
+    @AppStorage(StorageKeys.showDockIcon)
+    private var showDockIcon: Bool = StorageDefaults.showDockIcon
+    
     var pendingEnabler: DispatchWorkItem? = nil
     var notificationId: String? = nil
     var inactivityTimer: Timer? = nil
@@ -60,7 +63,9 @@ class SleepService: ObservableObject {
                         NSWorkspace.shared.open(url)
                     }
                     
-                    AppDelegate.hideApplication();
+                    if !self.showDockIcon {
+                        AppDelegate.hideApplication()
+                    }
                 }
             }
             

--- a/Clapet/StorageKeys.swift
+++ b/Clapet/StorageKeys.swift
@@ -6,8 +6,9 @@ struct StorageKeys {
     static let alreadySetup: String = "alreadySetup"
     static let skippedUpdates: String = "skippedUpdates"
     static let showMenuIcon: String = "showMenuIcon"
+    static let showDockIcon: String = "showDockIcon"
     static let lastUpdateCheck: String = "lastUpdateCheck"
-    static let checkForUpdates: String = "showMenuIcon"
+    static let checkForUpdates: String = "checkForUpdates"
     static let automaticSwitchNotification: String = "automaticSwitchNotification"
     static let enableInactivityDelay: String = "enableInactivityDelay"
     static let inactivityDelay: String = "inactivityDelay"
@@ -23,6 +24,7 @@ struct StorageDefaults {
     static let alreadySetup: Bool = false
     static let skippedUpdates: [String] = []
     static let showMenuIcon: Bool = true
+    static let showDockIcon: Bool = true
     static let checkForUpdates: Bool = true
     static let automaticSwitchNotification: Bool = false
     static let enableInactivityDelay: Bool = true
@@ -40,6 +42,7 @@ struct StorageDefaults {
         StorageKeys.automatic: automatic,
         StorageKeys.alreadySetup: alreadySetup,
         StorageKeys.showMenuIcon: showMenuIcon,
+        StorageKeys.showDockIcon: showDockIcon,
         StorageKeys.automaticSwitchNotification: automaticSwitchNotification,
         StorageKeys.enableInactivityDelay: enableInactivityDelay,
         StorageKeys.inactivityDelay: inactivityDelay,

--- a/Clapet/StorageKeys.swift
+++ b/Clapet/StorageKeys.swift
@@ -24,7 +24,7 @@ struct StorageDefaults {
     static let alreadySetup: Bool = false
     static let skippedUpdates: [String] = []
     static let showMenuIcon: Bool = true
-    static let showDockIcon: Bool = true
+    static let showDockIcon: Bool = false
     static let checkForUpdates: Bool = true
     static let automaticSwitchNotification: Bool = false
     static let enableInactivityDelay: Bool = true

--- a/Clapet/Views/Introduction.swift
+++ b/Clapet/Views/Introduction.swift
@@ -115,6 +115,8 @@ struct Introduction: View {
     }
     
     func finalizeSetup() {
+        //by default the showDockIcon is false on first launch so we can
+        //just hide the application from dock without checking
         AppDelegate.hideApplication()
         
         if launchOnStartup {

--- a/Clapet/Views/MenuBar.swift
+++ b/Clapet/Views/MenuBar.swift
@@ -21,6 +21,9 @@ struct MenuBar: Scene {
     @AppStorage(StorageKeys.sleepDurations)
     private var sleepDurations: [SleepDuration] = StorageDefaults.sleepDurations
     
+    @AppStorage(StorageKeys.showDockIcon)
+    private var showDockIcon: Bool = StorageDefaults.showDockIcon
+    
     @State
     private var settingsOpen: Bool = false
     
@@ -123,7 +126,7 @@ struct MenuBar: Scene {
                 NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
             }
             
-            //remove from alt tab when settings window when hidden
+            //remove from alt tab when settings window is closed/hidden
             Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) {
                 let window = NSApp.windows.filter {
                     $0.hasTitleBar && $0.title != "introduction".localize()
@@ -131,7 +134,10 @@ struct MenuBar: Scene {
                 
                 if let settings = window, !settings.isVisible {
                     settingsOpen = false
-                    AppDelegate.hideApplication()
+                    
+                    if !self.showDockIcon {
+                        AppDelegate.hideApplication()
+                    }
                     
                     $0.invalidate()
                 }

--- a/Clapet/Views/Settings/AdvancedSettings.swift
+++ b/Clapet/Views/Settings/AdvancedSettings.swift
@@ -51,7 +51,7 @@ struct AdvancedSettings: View {
     func resetSettings() {
         if let bundleID = Bundle.main.bundleIdentifier {
             UserDefaults.standard.removePersistentDomain(forName: bundleID)
-            alreadySetup = true
+            //alreadySetup = true
             
             ObservableObjectPublisher().send()
         }

--- a/Clapet/Views/Settings/GeneralSettings.swift
+++ b/Clapet/Views/Settings/GeneralSettings.swift
@@ -15,6 +15,9 @@ struct GeneralSettings: View {
     @AppStorage(StorageKeys.showMenuIcon)
     private var showMenuIcon: Bool = StorageDefaults.showMenuIcon
     
+    @AppStorage(StorageKeys.showDockIcon)
+    private var showDockIcon: Bool = StorageDefaults.showDockIcon
+    
     @AppStorage(StorageKeys.checkForUpdates)
     private var checkForUpdates: Bool = StorageDefaults.checkForUpdates
     
@@ -50,7 +53,14 @@ struct GeneralSettings: View {
                             Text("menu-bar-icon")
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
-                        .disabled(true)
+                        
+                        Toggle(isOn: $showDockIcon) {
+                            Text("dock-icon")
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .onChange(of: showDockIcon) { _ in
+                            toggleDockIcon()
+                        }
                         
                         Toggle(isOn: $checkForUpdates) {
                             Text("check-for-updates")
@@ -88,6 +98,14 @@ struct GeneralSettings: View {
         .frame(width: 410, height: 250)
         .padding(.vertical, 10)
         .padding(.horizontal, 20)
+    }
+    
+    func toggleDockIcon() {
+        if showDockIcon {
+            NSApp.setActivationPolicy(.regular)
+        } else {
+            NSApp.setActivationPolicy(.accessory)
+        }
     }
     
     func onLaunchOnStartupChange(launch: Bool) {

--- a/Clapet/Views/Settings/GeneralSettings.swift
+++ b/Clapet/Views/Settings/GeneralSettings.swift
@@ -58,9 +58,6 @@ struct GeneralSettings: View {
                             Text("dock-icon")
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
-                        .onChange(of: showDockIcon) { _ in
-                            toggleDockIcon()
-                        }
                         
                         Toggle(isOn: $checkForUpdates) {
                             Text("check-for-updates")
@@ -98,14 +95,6 @@ struct GeneralSettings: View {
         .frame(width: 410, height: 250)
         .padding(.vertical, 10)
         .padding(.horizontal, 20)
-    }
-    
-    func toggleDockIcon() {
-        if showDockIcon {
-            NSApp.setActivationPolicy(.regular)
-        } else {
-            NSApp.setActivationPolicy(.accessory)
-        }
     }
     
     func onLaunchOnStartupChange(launch: Bool) {

--- a/Clapet/Views/Settings/SettingsView.swift
+++ b/Clapet/Views/Settings/SettingsView.swift
@@ -2,6 +2,9 @@ import SwiftUI
 
 struct SettingsView: View {
     
+    @AppStorage(StorageKeys.showDockIcon)
+    private var showDockIcon: Bool = StorageDefaults.showDockIcon
+
     var body: some View {
         TabView {
             GeneralSettings().tabItem {
@@ -24,9 +27,13 @@ struct SettingsView: View {
                 Label("advanced", systemImage: "ellipsis.curlybraces")
             }
         }
-//        .onReceive(NotificationCenter.default.publisher(for: NSWindow.willCloseNotification)) { _ in
-//            AppDelegate.hideApplication()
-//        }
+        .onReceive(NotificationCenter.default.publisher(for: NSWindow.willCloseNotification)) { a in
+            if let window = a.object {
+                if (window as! NSWindow).isVisible && !self.showDockIcon {
+                    AppDelegate.hideApplication()
+                }
+            }
+        }
     }
     
 }

--- a/Clapet/Views/Settings/SettingsView.swift
+++ b/Clapet/Views/Settings/SettingsView.swift
@@ -23,9 +23,10 @@ struct SettingsView: View {
             AdvancedSettings().tabItem {
                 Label("advanced", systemImage: "ellipsis.curlybraces")
             }
-        }.onReceive(NotificationCenter.default.publisher(for: NSWindow.willCloseNotification)) { _ in
-            AppDelegate.hideApplication()
         }
+//        .onReceive(NotificationCenter.default.publisher(for: NSWindow.willCloseNotification)) { _ in
+//            AppDelegate.hideApplication()
+//        }
     }
     
 }

--- a/Clapet/en.lproj/Localizable.strings
+++ b/Clapet/en.lproj/Localizable.strings
@@ -68,6 +68,7 @@ your password each time sleep gets either disabled or enabled which can get anno
 "behavior" = "Behavior";
 "launch-at-login" = "Launch at login";
 "menu-bar-icon" = "Show menu bar icon";
+"dock-icon" = "Show dock icon";
 "check-for-updates" = "Check for updates";
 "check-for-updates-description" = "Checks for available updates every week and on application launch";
 "inactivity" = "Inactivity";

--- a/Clapet/fr.lproj/Localizable.strings
+++ b/Clapet/fr.lproj/Localizable.strings
@@ -69,6 +69,7 @@ qui peut devenir gênant.
 "behavior" = "Comportement";
 "launch-at-login" = "Lancer au démarrage";
 "menu-bar-icon" = "Icone dans la barre de menu";
+"dock-icon" = "Icone dans le dock";
 "check-for-updates" = "Vérifier les mises à jour";
 "check-for-updates-description" = "Vérifie si il y a des mises à jour disponibles chaque semaine et au lancement de l'application";
 "inactivity" = "Inactivité";


### PR DESCRIPTION
I don't fully understand how the `alreadySetup` variable works, so I am simply disabling the check for now.